### PR TITLE
Updates based on epic.LAN configs

### DIFF
--- a/overlay/etc/nginx/sites-available/generic.conf
+++ b/overlay/etc/nginx/sites-available/generic.conf
@@ -15,7 +15,7 @@ server {
 
 	proxy_ignore_headers Expires Cache-Control;
 	proxy_cache_key   $uri$slice_range;
-	proxy_cache_valid 200 206 7d;
+	proxy_cache_valid 200 206 3650d;
 	proxy_set_header  Range $slice_range;
 
 	# Only download one copy at a time and use a large timeout so
@@ -29,11 +29,13 @@ server {
 
 	# Allow caching of 200 but not 301 or 302 as our cache key may not include query params
 	# hence may not be valid for all users
-	proxy_cache_valid 200 3650d;
 	proxy_cache_valid 301 302 0;
 
 	# Enable cache revalidation
 	proxy_cache_revalidate on;
+	
+	# Battle.net Fix
+	proxy_hide_header ETag;
 
 	# Don't cache requests marked as nocache=1
 	proxy_cache_bypass $arg_nocache;


### PR DESCRIPTION
 - Ignore ETag header (fixes Blizzard issues)
 - Remove duplicated expiry