### PR TITLE
convert memory cache, disk cache and cache duration to environment vars

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,9 +16,6 @@ RUN	chmod 755 /scripts/*			;\
 	mkdir -m 755 -p /tmp/nginx/		;\
 	chown -R ${WEBUSER}:${WEBUSER} /data/	;\
 	mkdir -p /etc/nginx/sites-enabled	;\
-	sed -i "s/CACHE_MEM_SIZE/${CACHE_MEM_SIZE}/"  /etc/nginx/sites-available/generic.conf	;\
-	sed -i "s/CACHE_DISK_SIZE/${CACHE_DISK_SIZE}/" /etc/nginx/sites-available/generic.conf	;\
-	sed -i "s/CACHE_MAX_AGE/${CACHE_MAX_AGE}/"    /etc/nginx/sites-available/generic.conf	;\
 	ln -s /etc/nginx/sites-available/generic.conf /etc/nginx/sites-enabled/generic.conf
 
 VOLUME ["/data/logs", "/data/cache", "/var/www"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,9 @@ MAINTAINER SteamCache.Net Team <team@steamcache.net>
 
 ENV GENERICCACHE_VERSION 1
 ENV WEBUSER nginx
+ENV CACHE_MEM_SIZE 500m
+ENV CACHE_DISK_SIZE 500000m
+ENV CACHE_MAX_AGE 3560d
 
 COPY overlay/ /
 
@@ -13,6 +16,9 @@ RUN	chmod 755 /scripts/*			;\
 	mkdir -m 755 -p /tmp/nginx/		;\
 	chown -R ${WEBUSER}:${WEBUSER} /data/	;\
 	mkdir -p /etc/nginx/sites-enabled	;\
+	sed -i "s/CACHE_MEM_SIZE/${CACHE_MEM_SIZE}/"  /etc/nginx/sites-available/generic.conf	;\
+	sed -i "s/CACHE_DISK_SIZE/${CACHE_DISK_SIZE}/" /etc/nginx/sites-available/generic.conf	;\
+	sed -i "s/CACHE_MAX_AGE/${CACHE_MAX_AGE}/"    /etc/nginx/sites-available/generic.conf	;\
 	ln -s /etc/nginx/sites-available/generic.conf /etc/nginx/sites-enabled/generic.conf
 
 VOLUME ["/data/logs", "/data/cache", "/var/www"]

--- a/overlay/etc/nginx/sites-available/generic.conf
+++ b/overlay/etc/nginx/sites-available/generic.conf
@@ -1,4 +1,4 @@
-proxy_cache_path /data/cache/cache levels=2:2 keys_zone=generic:500m inactive=200d max_size=500000m loader_files=1000 loader_sleep=50ms loader_threshold=300ms;
+proxy_cache_path /data/cache/cache levels=2:2 keys_zone=generic:CACHE_MEM_SIZE inactive=200d max_size=CACHE_DISK_SIZE loader_files=1000 loader_sleep=50ms loader_threshold=300ms;
 
 server {
   listen 80;
@@ -15,7 +15,7 @@ server {
 
     proxy_ignore_headers Expires Cache-Control;
     proxy_cache_key      $uri$slice_range;
-    proxy_cache_valid 200 206 3650d;
+    proxy_cache_valid 200 206 CACHE_MAX_AGE;
     proxy_set_header  Range $slice_range;
 
     # Only download one copy at a time and use a large timeout so

--- a/overlay/scripts/bootstrap.sh
+++ b/overlay/scripts/bootstrap.sh
@@ -1,6 +1,11 @@
 #!/bin/sh
 set -e
 
+sed -i "s/CACHE_MEM_SIZE/${CACHE_MEM_SIZE}/"  /etc/nginx/sites-available/generic.conf
+sed -i "s/CACHE_DISK_SIZE/${CACHE_DISK_SIZE}/" /etc/nginx/sites-available/generic.conf
+sed -i "s/CACHE_MAX_AGE/${CACHE_MAX_AGE}/"    /etc/nginx/sites-available/generic.conf
+
+
 /usr/sbin/nginx -t
 
 /usr/sbin/nginx -g "daemon off;"

--- a/readme.md
+++ b/readme.md
@@ -78,6 +78,26 @@ You can find a list of domains you will want to use for each service over on [uk
 
 Regular commodity hardware (a single 2TB WD Black on an HP Microserver) can achieve peak throughputs of 30MB/s+ using this setup (depending on the specific content being served).
 
+## Tweaking Cache sizes
+
+Two environment variables are available to manage both the memory and disk cache for a particular container, and are set to the following defaults.
+```
+CACHE_MEM_SIZE 500m
+CACHE_DISK_SIZE 500000m
+```
+
+In addition, there is an environment variable to control the max cache age
+
+```
+CACHE_MAX_AGE 3650d
+````
+
+You can override these at run time by adding the following to your docker run command.  They accept the standard nginx notation for sizes (k/m/g/t) and durations (m/h/d)
+
+```
+-e CACHE_MEM_SIZE=4000m -e CACHE_DISK_SIZE=1000g
+```
+
 ## Monitoring
 
 Access logs are written to /data/logs. If you don't particularly care about keeping them, you don't need to mount an external volume into the container.


### PR DESCRIPTION
Comments welcome.  This should allow people to define the parts that mean the most to them, allowing contraints on memory and disk usage on a per container basis.