### PR TITLE
Added x-forwarded-for to the access.log

### DIFF
--- a/overlay/etc/nginx/nginx.conf
+++ b/overlay/etc/nginx/nginx.conf
@@ -21,7 +21,7 @@ http {
 	access_log /var/log/nginx/access.log;
 	error_log /var/log/nginx/error.log;
 
-	log_format cachelog '$remote_addr - $remote_user [$time_local] "$request" $status $body_bytes_sent "$http_referer" "$http_user_agent" "$upstream_cache_status" "$host" "$http_range"';
+	log_format cachelog '$remote_addr / $http_x_forwarded_for - $remote_user [$time_local] "$request" $status $body_bytes_sent "$http_referer" "$http_user_agent" "$upstream_cache_status" "$host" "$http_range"';
 
 	gzip on;
 


### PR DESCRIPTION
Allow access to the x-forwarded-for header for use cases where a cache
instance is hiding behind another cache