### PR TITLE
Disable IPv6 lookup when caching.

### DIFF
--- a/overlay/etc/nginx/sites-available/generic.conf
+++ b/overlay/etc/nginx/sites-available/generic.conf
@@ -6,7 +6,7 @@ server {
   access_log /data/logs/access.log cachelog;
   error_log /data/logs/error.log;
 
-  resolver 8.8.8.8 8.8.4.4;
+  resolver 8.8.8.8 8.8.4.4 ipv6=off;
 
   location / {
     # Cache Location


### PR DESCRIPTION
This change prevents resolving IPv6 addresses when trying to cache files. Specifically when attempting to cache Windows Updates.

Before this change, Windows Update would fail, and the error log would be full of entries like this:

`2018/06/19 09:53:50 [crit] 12#12: *246 connect() to [2a01:111:2003::50]:80 failed (99: Address not available) while connecting to upstream, client: x.x.x.x, server: , request: "GET /c/msdownload/update/others/2014/10/15497503_6af6c78fc024c0a76b949da2bf0384dbe6772f98.cab HTTP/1.1", upstream: "http://[2a01:111:2003::50]:80/c/msdownload/update/others/2014/10/15497503_6af6c78fc024c0a76b949da2bf0384dbe6772f98.cab", host: "download.windowsupdate.com"`

Telling nginx to not resolve IPv6 addresses fixes this.
