### PR TITLE
Take ownership of cache files at startup

### DIFF
--- a/overlay/scripts/bootstrap.sh
+++ b/overlay/scripts/bootstrap.sh
@@ -5,10 +5,11 @@ sed -i "s/CACHE_MEM_SIZE/${CACHE_MEM_SIZE}/"  /etc/nginx/sites-available/generic
 sed -i "s/CACHE_DISK_SIZE/${CACHE_DISK_SIZE}/" /etc/nginx/sites-available/generic.conf
 sed -i "s/CACHE_MAX_AGE/${CACHE_MAX_AGE}/"    /etc/nginx/sites-available/generic.conf
 
-echo "Checking permissions (This may take a long time if the permissions are incorrect on large caches)..."
-find /data \! -user ${WEBUSER} -exec chown ${WEBUSER}:${WEBUSER} '{}' +
-
-echo "Done. Starting caching server."
+if [ `stat -c '%U' /data/cache` != "${WEBUSER}" ] || [ `stat -c '%U' /data/logs` != "${WEBUSER}" ] || [ `stat -c '%U' /data/info` != "${WEBUSER}" ] ; then
+    echo "Checking permissions (This may take a long time if the permissions are incorrect on large caches)..."
+    find /data \! -user ${WEBUSER} -exec chown ${WEBUSER}:${WEBUSER} '{}' +
+    echo "Done. Starting caching server."
+fi
 
 /usr/sbin/nginx -t
 

--- a/overlay/scripts/bootstrap.sh
+++ b/overlay/scripts/bootstrap.sh
@@ -5,8 +5,9 @@ sed -i "s/CACHE_MEM_SIZE/${CACHE_MEM_SIZE}/"  /etc/nginx/sites-available/generic
 sed -i "s/CACHE_DISK_SIZE/${CACHE_DISK_SIZE}/" /etc/nginx/sites-available/generic.conf
 sed -i "s/CACHE_MAX_AGE/${CACHE_MAX_AGE}/"    /etc/nginx/sites-available/generic.conf
 
-echo "Checking permissions..."
-chown -R ${WEBUSER}:${WEBUSER} /data/cache /data/info /data/logs
+echo "Checking permissions (This may take a long time if the permissions are incorrect on large caches)..."
+find /data \! -user ${WEBUSER} -exec chown ${WEBUSER}:${WEBUSER} '{}' +
+
 echo "Done. Starting caching server."
 
 /usr/sbin/nginx -t

--- a/overlay/scripts/bootstrap.sh
+++ b/overlay/scripts/bootstrap.sh
@@ -5,11 +5,10 @@ sed -i "s/CACHE_MEM_SIZE/${CACHE_MEM_SIZE}/"  /etc/nginx/sites-available/generic
 sed -i "s/CACHE_DISK_SIZE/${CACHE_DISK_SIZE}/" /etc/nginx/sites-available/generic.conf
 sed -i "s/CACHE_MAX_AGE/${CACHE_MAX_AGE}/"    /etc/nginx/sites-available/generic.conf
 
-if [ `stat -c '%U' /data/cache` != "${WEBUSER}" ] || [ `stat -c '%U' /data/logs` != "${WEBUSER}" ] || [ `stat -c '%U' /data/info` != "${WEBUSER}" ] ; then
-    echo "Checking permissions (This may take a long time if the permissions are incorrect on large caches)..."
-    find /data \! -user ${WEBUSER} -exec chown ${WEBUSER}:${WEBUSER} '{}' +
-    echo "Done. Starting caching server."
-fi
+echo "Checking permissions (This may take a long time if the permissions are incorrect on large caches)..."
+find /data \! -user ${WEBUSER} -exec chown ${WEBUSER}:${WEBUSER} '{}' +
+
+echo "Done. Starting caching server."
 
 /usr/sbin/nginx -t
 

--- a/overlay/scripts/bootstrap.sh
+++ b/overlay/scripts/bootstrap.sh
@@ -5,6 +5,9 @@ sed -i "s/CACHE_MEM_SIZE/${CACHE_MEM_SIZE}/"  /etc/nginx/sites-available/generic
 sed -i "s/CACHE_DISK_SIZE/${CACHE_DISK_SIZE}/" /etc/nginx/sites-available/generic.conf
 sed -i "s/CACHE_MAX_AGE/${CACHE_MAX_AGE}/"    /etc/nginx/sites-available/generic.conf
 
+echo "Checking permissions..."
+chown -R ${WEBUSER}:${WEBUSER} /data/cache /data/info /data/logs
+echo "Done. Starting caching server."
 
 /usr/sbin/nginx -t
 


### PR DESCRIPTION
This will steal ownership of the cache files at startup - fixes #34

On large caches this could take a while, We could add a flag to not take ownership for those that know what we're doing if it becomes a problem.