### PR TITLE
Set use_temp_path to off to avoid cross-device writes

### DIFF
--- a/overlay/etc/nginx/sites-available/generic.conf
+++ b/overlay/etc/nginx/sites-available/generic.conf
@@ -1,4 +1,4 @@
-proxy_cache_path /data/cache/cache levels=2:2 keys_zone=generic:CACHE_MEM_SIZE inactive=200d max_size=CACHE_DISK_SIZE loader_files=1000 loader_sleep=50ms loader_threshold=300ms;
+proxy_cache_path /data/cache/cache levels=2:2 keys_zone=generic:CACHE_MEM_SIZE inactive=200d max_size=CACHE_DISK_SIZE loader_files=1000 loader_sleep=50ms loader_threshold=300ms use_temp_path=off;
 
 server {
   listen 80;


### PR DESCRIPTION
Per the [nginx documentation](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_temp_path), the default behaviour of the `proxy_cache_path` directive will store temporary files in a separate folder to the cache folder. By default, that path is under `/var/nginx`, which on most cache container setups will be on a separate device entirely.