### PR TITLE
Set the reuseport flag on listen directives

### DIFF
--- a/overlay/etc/nginx/sites-available/default.conf
+++ b/overlay/etc/nginx/sites-available/default.conf
@@ -1,5 +1,5 @@
 server {
-        listen *:80 default;
+        listen *:80 default reuseport;
 
         location / {
                 root /var/www/;

--- a/overlay/etc/nginx/sites-available/generic.conf
+++ b/overlay/etc/nginx/sites-available/generic.conf
@@ -1,7 +1,7 @@
 proxy_cache_path /data/cache/cache levels=2:2 keys_zone=generic:CACHE_MEM_SIZE inactive=200d max_size=CACHE_DISK_SIZE loader_files=1000 loader_sleep=50ms loader_threshold=300ms;
 
 server {
-  listen 80;
+  listen 80 reuseport;
 
   access_log /data/logs/access.log cachelog;
   error_log /data/logs/error.log;


### PR DESCRIPTION
This allows each worker process to bind directly to the IP:port, instead of going via a single listener process.

See also [this](https://www.nginx.com/blog/socket-sharding-nginx-release-1-9-1/) nginx blog post detailing the performance differences.