### PR TITLE
Use asyncio threads

### DIFF
--- a/overlay/etc/nginx/nginx.conf
+++ b/overlay/etc/nginx/nginx.conf
@@ -9,6 +9,7 @@ events {
 }
 
 http {
+	aio threads;
 	sendfile on;
 	tcp_nopush on;
 	tcp_nodelay on;


### PR DESCRIPTION
This allows IO operations to be done via Linux asyncio threads instead of blocking a worker process in nginx.

See also [nginx blog post](https://www.nginx.com/blog/thread-pools-boost-performance-9x/).