### PR TITLE
Avoid having to run multiple instances

### DIFF
--- a/overlay/etc/nginx/sites-available/generic.conf
+++ b/overlay/etc/nginx/sites-available/generic.conf
@@ -9,6 +9,12 @@ server {
   resolver 8.8.8.8 8.8.4.4 ipv6=off;
 
   location / {
+  
+    # Abort early in the case of circular requests 
+    if ($http_SteamCache = $hostname) {
+      return 508;
+    }
+    
     # Cache Location
     slice 1m;
     proxy_cache generic;
@@ -53,6 +59,7 @@ server {
     proxy_set_header Host $host;
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header SteamCache $hostname
 
     # Debug Headers
     add_header X-Upstream-Status $upstream_status;

--- a/overlay/etc/nginx/sites-available/generic.conf
+++ b/overlay/etc/nginx/sites-available/generic.conf
@@ -59,7 +59,7 @@ server {
     proxy_set_header Host $host;
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header SteamCache $hostname
+    proxy_set_header SteamCache $hostname;
 
     # Debug Headers
     add_header X-Upstream-Status $upstream_status;

--- a/overlay/etc/nginx/sites-available/generic.conf
+++ b/overlay/etc/nginx/sites-available/generic.conf
@@ -14,7 +14,7 @@ server {
     proxy_cache generic;
 
     proxy_ignore_headers Expires Cache-Control;
-    proxy_cache_key      $uri$slice_range;
+    proxy_cache_key      $host$uri$slice_range;
     proxy_cache_valid 200 206 CACHE_MAX_AGE;
     proxy_set_header  Range $slice_range;
 


### PR DESCRIPTION
Including the HTTP Host header in the cache key will allow multiple services (origin, blizzard, etc) to use the same instance of steamcache without having cache collisions.