### PR TITLE
Fix loop detection

### DIFF
--- a/overlay/etc/nginx/sites-available/generic.conf
+++ b/overlay/etc/nginx/sites-available/generic.conf
@@ -10,7 +10,7 @@ server {
 
   location / {
     # Abort any circular requests
-	if ($http_X-SteamCache-Processed-By = $hostname) {
+	if ($http_X_SteamCache_Processed_By = $hostname) {
 		return 508;
 	}
 
@@ -23,6 +23,7 @@ server {
     proxy_cache_valid 200 206 CACHE_MAX_AGE;
     proxy_set_header  Range $slice_range;
 	proxy_set_header X-SteamCache-Processed-By $hostname;
+	add_header X-SteamCache-Processed-By $hostname,$http_X_SteamCache_Processed_By;
 
     # Only download one copy at a time and use a large timeout so
     # this really happens, otherwise we end up wasting bandwith


### PR DESCRIPTION
From nginx docs
$http_()
Arbitrary request header field; the last part of a variable name is the
field name converted to lower case with dashes replaced by underscores

Also added X-SteamCache-Processed-By for downstream processing

Fixes #67