### PR TITLE
WIP: Implement proxy_read_timeout

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,7 @@ workflows:
              branches:
                only: 
                  - legacy
+                 - proxy_read_timeout
       - publish_latest:
           context: docker-hub
           requires:

--- a/overlay/etc/nginx/sites-available/generic.conf.d/root/20_cache.conf
+++ b/overlay/etc/nginx/sites-available/generic.conf.d/root/20_cache.conf
@@ -1,7 +1,10 @@
     # Cache Location
     slice 1m;
     proxy_cache generic;
-
+    
+    # It has been suggested that setting the proxy read timeout fixes some slow download issues
+    proxy_read_timeout 300;
+    
     proxy_ignore_headers Expires Cache-Control;
     proxy_cache_valid 200 206 CACHE_MAX_AGE;
     proxy_set_header  Range $slice_range;


### PR DESCRIPTION
Suggestions on https://github.com/steamcache/steamcache/issues/44 imply setting proxy_read_timeout may provide a solution to the slow steam downloads. This isn't expected to resolve things but lets give it a go!