### PR TITLE
Added nginx checking and fast permissions check

### DIFF
--- a/overlay/hooks/entrypoint-pre.d/20_perms_check.sh
+++ b/overlay/hooks/entrypoint-pre.d/20_perms_check.sh
@@ -1,6 +1,14 @@
-#!/bin/sh
-set -e
+#!/bin/bash
+if [ -d "/data/cache/cache" ]; then
+	echo "Running fast permissions check"
+	ls -l /data/cache/cache | tail --lines=+2 | grep -v ${WEBUSER} > /dev/null
 
-echo "Checking permissions (This may take a long time if the permissions are incorrect on large caches)..."
-find /data \! -user ${WEBUSER} -exec chown ${WEBUSER}:${WEBUSER} '{}' +
-echo "Permisions ok"
+	if [[ $? -eq 0 || "$FORCE_PERMS_CHECK" == "true" ]]; then
+		echo "Doing full checking of permissions (This WILL take a long time on large caches)..."
+		find /data \! -user ${WEBUSER} -exec chown ${WEBUSER}:${WEBUSER} '{}' +
+		echo "Permissions ok"
+	else
+		echo "Fast permissions check successful, if you have any permissions error try running with -e FORCE_PERMS_CHECK = true"
+	fi
+
+fi

--- a/overlay/hooks/supervisord-pre.d/99_config_check.sh
+++ b/overlay/hooks/supervisord-pre.d/99_config_check.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 set -e
+echo "Currently configured config:"
+/scripts/getconfig.sh /etc/nginx/nginx.conf
 
 echo "Checking nginx config"
 /usr/sbin/nginx -t

--- a/overlay/scripts/getconfig.sh
+++ b/overlay/scripts/getconfig.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+get_file_contents() {
+	FILES=$1
+	local FILE;
+	for FILE in $FILES; do
+		echo "# Including $FILE"
+		local LINE
+		while read LINE; do
+			CLEANLINE=`echo $LINE | sed -e 's/^[[:space:]]*//g' -e 's/[[:space:]]*\$//g'`
+			if [[ "$CLEANLINE" =~ ^include ]]; then
+				local CL_LEN
+				local INCUDE
+				CL_LEN=${#CLEANLINE}-9;
+				INCLUDE=${CLEANLINE:8:$CL_LEN}
+				get_file_contents "$INCLUDE"
+			else
+				echo $LINE
+			fi
+		done < $FILE
+		echo "# Finished including $FILE"
+
+	done
+}
+
+
+main() {
+
+	echo "NGINX CONFIG DUMP FOR $1"
+
+	cd `dirname $1`
+
+	get_file_contents $1
+
+}
+
+
+
+main `readlink -f $1`


### PR DESCRIPTION
Added full diagnostics on startup to show full running config, and fast permissions checks that have a "peak" into the cache dir to check user perms instead of the full `find ` check.

The original full check can be forced by setting `-e FORCE_PERMS_CHECK=true`