### PR TITLE
Do not cache Valve server-status

### DIFF
--- a/overlay/etc/nginx/sites-available/generic.conf.d/10_generic.conf
+++ b/overlay/etc/nginx/sites-available/generic.conf.d/10_generic.conf
@@ -15,3 +15,8 @@
 	add_header X-LanCache-Processed-By $hostname;
 	return 204;
   }
+
+  location = /server-status {
+  	proxy_no_cache 1;
+ 	proxy_cache_bypass 1
+}

--- a/overlay/etc/nginx/sites-available/generic.conf.d/10_generic.conf
+++ b/overlay/etc/nginx/sites-available/generic.conf.d/10_generic.conf
@@ -18,5 +18,5 @@
 
   location = /server-status {
   	proxy_no_cache 1;
- 	proxy_cache_bypass 1
+ 	proxy_cache_bypass 1;
 }


### PR DESCRIPTION
Looking through the logs I noticed that Valve has a server-status url on their servers which seems to report the load of said server, and that Monolithic/Generic caches the response by default

For example, http://cache1-sea1.steamcontent.com/server-status returns 

```"status"
{
	"csid"		"3"
	"load"		"10"
	"cell"		"31"
}
```

This is a very minor feature, but it could potentially speed up cache misses by honoring what appears to be Valve's automatic load balancing.

I don't have a monolithic cache set up to test this against at the moment, but I should report back sometime this weekend.