### PR TITLE
WIP Enabled support for ipv6. Plus feature of multiple ips for macvlans.

### DIFF
--- a/overlay/etc/nginx/sites-available/10_generic.conf
+++ b/overlay/etc/nginx/sites-available/10_generic.conf
@@ -1,6 +1,7 @@
 
 server {
   listen 80 reuseport;
+  listen [::]:80 reuseport;
 
   access_log /data/logs/access.log cachelog;
   error_log /data/logs/error.log;

--- a/overlay/etc/nginx/sites-available/generic.conf.d/10_generic.conf
+++ b/overlay/etc/nginx/sites-available/generic.conf.d/10_generic.conf
@@ -1,4 +1,4 @@
-  resolver UPSTREAM_DNS ipv6=off;
+  resolver UPSTREAM_DNS;
 
   location / {
 

--- a/overlay/hooks/entrypoint-pre.d/10_setup.sh
+++ b/overlay/hooks/entrypoint-pre.d/10_setup.sh
@@ -8,3 +8,9 @@ sed -i "s/CACHE_DISK_SIZE/${CACHE_DISK_SIZE}/" /etc/nginx/conf.d/20_proxy_cache_
 sed -i "s/CACHE_MAX_AGE/${CACHE_MAX_AGE}/"    /etc/nginx/sites-available/generic.conf.d/root/20_cache.conf
 sed -i "s/UPSTREAM_DNS/${UPSTREAM_DNS}/"    /etc/nginx/sites-available/generic.conf.d/10_generic.conf
 
+if ! [ -z "${ADDITIONAL_IPS}" ]; then                                                     
+  for IP in ${ADDITIONAL_IPS}; do     
+	echo ";## Additional cache $IP"
+	ip a a $IP dev eth0
+  done                                                                                
+fi 


### PR DESCRIPTION
## IPV6
This PR removes limitations that prevents ipv6 usage.
With this changes user can run cache with ipv6 support.

In case no macvlan is setup but docker is configured for ipv6 support

```docker
sudo docker run -d \
        -e UPSTREAM_DNS="[fd01::1]:6453" \
        lancachenet/monolithic:latest
```

In case macvlan (name publan) network is setup

```docker
sudo docker run -d \
        -e UPSTREAM_DNS="[fd01::1]:6453" \
        --ip6=fd01::c:1 \
        --net=publan \
        lancachenet/monolithic:latest
```

Note, how to setup UPSTREAM_DNS ip (+ optional port) properly. 
Ipv6 : ```[fd01::1]:6453 [fd01::2]```
Ipv4 : ```8.8.8.8 1.1.1.1:53```
mixed : ```8.8.8.8 [fd01::1]:6453```

## ADDITIONAL IPS
This feature requires **macvlan** to be setup and the container to be granted **NET_ADMIN** capability.

Since when using macvlan only one external IP can be set (one ipv4 + one ipv6) , this feature makes container to use additional IPs.

Assuming macvlan is set like this:
```
 sudo docker network create -d macvlan \
	 --subnet=fd01::/64 \
	 --subnet=192.168.1.0/24 \
	 --ip-range=192.168.1.192/28 \
	 --ipv6 \
	 -o parent=eth0 publan  
```

User can run the container like this:
```
sudo docker run -d \
        -e ADDITIONAL_IPS="fd01::c:2/64 fd01::c:3/64 192.168.1.202/24 192.168.1.203/24" \
        --ip6=fd01::c:1 \
        --ip=192.168.1.201 \
        --net=publan \
        --cap-add=NET_ADMIN \
        lancachenet/monolithic:latest
```

## TEST

You can get images for testing here: https://hub.docker.com/r/pamidur/lancache/tags