### PR TITLE
Allow slice_size changes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,16 +1,8 @@
 workflows:
-  version: 2
+  version: 2.1
   build_test_deploy:
     jobs:
       - test
-      - publish_tag:
-          context: docker-hub
-          requires:
-            - test
-          filters:
-             branches:
-               only: 
-                 - legacy
       - publish_latest:
           context: docker-hub
           requires:
@@ -23,40 +15,22 @@ workflows:
           context: circle-api
           requires:
             - publish_latest
-  monthly:
-    triggers:
-      - schedule:
-          cron: "0 0 1 * *"
-          filters:
-            branches:
-              only:
-                - legacy
-    jobs:
-      - test
-      - publish_tag:
-          context: docker-hub
-          requires:
-            - test
-          filters:
-             branches:
-               only: 
-                 - legacy
 
-version: 2
+version: 2.1
+executors:
+  testbuild-executor:
+    machine:
+      image: ubuntu-1604:201903-01
 jobs:
   test:
-    docker:
-      - image: circleci/python:2-jessie
+    executor: testbuild-executor
     steps:
       - checkout
-
-      - setup_remote_docker:   # (2)
-          docker_layer_caching: false # (3)
       - run:
           name: Install goss
           command: |
             # rather than give internet scripts SU rights, we install to local user bin and add to path
-            mkdir ~/bin
+            [ -d ~/bin ] || mkdir ~/bin
             export GOSS_DST=~/bin
             export PATH=$PATH:~/bin
             curl -fsSL https://goss.rocks/install | sh
@@ -66,64 +40,45 @@ jobs:
           command: |
             # Don't forget path!
             export PATH=$PATH:~/bin
-            # Important, change from mount to work on remote docker, see https://github.com/aelsabbahy/goss/pull/271
-            # If using machine image you do not need this.
-            export GOSS_FILES_STRATEGY=cp
-            ./run-tests.sh circleci keepimage
+            ./run-tests.sh --circleci --keepimage
       - run:
           name: Save docker image
           command: |
-            mkdir -p workspace
+            [ -d workspace ] || mkdir workspace
             docker save -o workspace/lancachenet-generic.tar lancachenet/generic:goss-test
+            #Download from Artifacts and Load this into your own docker using the following command
+            #docker load -i /tmp/workspace/lancachenet-generic.tar
+      - store_test_results:
+          path: reports/goss/report.xml
+      - store_artifacts:
+          path: reports
+          destination: reports
+      - store_artifacts:
+          path: workspace/lancachenet-generic.tar
+          destination: docker-lancachenet-generic.tar
       - persist_to_workspace:
           root: workspace
           paths:
             lancachenet-generic.tar
-      - store_test_results:
-          path: reports
-      - store_artifacts:
-          path: reports
-          destination: reports
-  publish_tag:
-    docker:
-      - image: circleci/python:2-jessie
-    steps:
-      - setup_remote_docker:   # (2)
-          docker_layer_caching: true # (3)
-      - attach_workspace:
-          at: /tmp/workspace
-      - run:
-          name: "Deploy latest to docker hub"
-          command: |
-            docker login -u $DOCKER_USER -p $DOCKER_PASS
-            #docker build -t lancachenet/generic:latest .
-            docker load -i /tmp/workspace/lancachenet-generic.tar
-            docker tag lancachenet/generic:goss-test lancachenet/generic:$CIRCLE_BRANCH
-            docker push lancachenet/generic:$CIRCLE_BRANCH
   publish_latest:
-    docker:
-      - image: circleci/python:2-jessie
+    executor: testbuild-executor
     steps:
-      - setup_remote_docker:   # (2)
-          docker_layer_caching: false # (3)
       - attach_workspace:
           at: /tmp/workspace
       - run:
           name: "Deploy latest to docker hub"
           command: |
-            docker login -u $DOCKER_USER -p $DOCKER_PASS
-            #docker build -t lancachenet/generic:latest .
             docker load -i /tmp/workspace/lancachenet-generic.tar
+            docker login -u $DOCKER_USER -p $DOCKER_PASS
             docker tag lancachenet/generic:goss-test lancachenet/generic:latest
             docker push lancachenet/generic:latest
   build_children:
-    docker:
-      - image: circleci/python:2-jessie
+    executor: testbuild-executor
     steps:
       - run:
           name: "Request API to build children"
           command: |
-              for child in "monolithic"; do
+              for child in {"monolithic"}; do
                  echo "Asking API to trigger build for $child"
                  curl -X POST --header "Content-Type: application/json" -d '{"branch":"master"}' https://circleci.com/api/v1.1/project/github/lancachenet/$child/build?circle-token=${CIRCLE_API_USER_TOKEN}
               done

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,13 @@
 FROM lancachenet/ubuntu-nginx:latest
 MAINTAINER LanCache.Net Team <team@lancache.net>
 
-ENV GENERICCACHE_VERSION=2 \
+ENV GENERICCACHE_VERSION=2 \    
     WEBUSER=www-data \
+	CACHE_MODE=generic \
     CACHE_MEM_SIZE=500m \
-    CACHE_DISK_SIZE=500000m \
+    CACHE_DISK_SIZE=1000000m \
     CACHE_MAX_AGE=3560d \
+	CACHE_SLICE_SIZE=1m \
     UPSTREAM_DNS="8.8.8.8 8.8.4.4" \
     BEAT_TIME=1h \
     LOGFILE_RETENTION=3560 \

--- a/overlay/hooks/entrypoint-pre.d/05_config_check.sh
+++ b/overlay/hooks/entrypoint-pre.d/05_config_check.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+echo "Checking cache configuration"
+
+
+print_confighash_warning () {
+	echo ""
+	echo "ABORTING STARTUP TO AVOID POTENTIALLY INVALIDATING THE CACHE"
+	echo ""
+	echo "If you are happy that this cache is valid with the current config changes"
+	echo "please delete \`/<cache_mount>/CONFIGHASH\`"
+	echo ""
+	echo "See: https://lancache.net/docs/advanced/config-hash/ for more details"
+
+}
+
+DETECTED_CACHE_KEY=`grep proxy_cache_key /etc/nginx/sites-available/generic.conf.d/root/30_cache_key.conf | awk '{print $2}'`
+NEWHASH="GENERICCACHE_VERSION=${GENERICCACHE_VERSION};CACHE_MODE=${CACHE_MODE};CACHE_SLICE_SIZE=${CACHE_SLICE_SIZE};CACHE_KEY=${DETECTED_CACHE_KEY}"
+
+if [ -d /data/cache/cache ]; then
+	echo " Detected existing cache data, checking config hash for consistency"
+	if [ -f /data/cache/CONFIGHASH ]; then
+		OLDHASH=`cat /data/cache/CONFIGHASH`
+		if [ ${OLDHASH} != ${NEWHASH} ]; then
+			echo "ERROR: Detected CONFIGHASH does not match current CONFIGHASH"
+			echo " Detected: ${OLDHASH}"
+			echo " Current:  ${NEWHASH}"
+			print_confighash_warning ${NEWHASH}
+			exit -1;
+		else
+			echo " CONFIGHASH matches current configuration"
+		fi
+	else
+		echo " Could not find CONFIGHASH for existing cachedata"
+		echo "  This is either an upgrade from an older instance of Lancache"
+		echo "  or CONFIGHASH has been deleted intentionally"
+		echo ""
+		echo " Creating CONFIGHASH from current live configuration"
+		echo "   Current:  ${NEWHASH}"
+		echo ""
+		echo "  See: https://lancache.net/docs/advanced/config-hash/ for more details"
+	fi
+fi
+
+mkdir -p /data/cache/cache
+echo ${NEWHASH} > /data/cache/CONFIGHASH

--- a/overlay/hooks/entrypoint-pre.d/10_setup.sh
+++ b/overlay/hooks/entrypoint-pre.d/10_setup.sh
@@ -6,5 +6,5 @@ sed -i "s/^user .*/user ${WEBUSER};/" /etc/nginx/nginx.conf
 sed -i "s/CACHE_MEM_SIZE/${CACHE_MEM_SIZE}/"  /etc/nginx/conf.d/20_proxy_cache_path.conf
 sed -i "s/CACHE_DISK_SIZE/${CACHE_DISK_SIZE}/" /etc/nginx/conf.d/20_proxy_cache_path.conf
 sed -i "s/CACHE_MAX_AGE/${CACHE_MAX_AGE}/"    /etc/nginx/sites-available/generic.conf.d/root/20_cache.conf
+sed -i "s/slice 1m;/slice ${CACHE_SLICE_SIZE:-1m};/" /etc/nginx/sites-available/generic.conf.d/root/20_cache.conf
 sed -i "s/UPSTREAM_DNS/${UPSTREAM_DNS}/"    /etc/nginx/sites-available/generic.conf.d/10_generic.conf
-

--- a/overlay/hooks/entrypoint-pre.d/10_setup.sh
+++ b/overlay/hooks/entrypoint-pre.d/10_setup.sh
@@ -1,10 +1,9 @@
 #!/bin/sh
 set -e
-
 echo "worker_processes ${NGINX_WORKER_PROCESSES};" > /etc/nginx/workers.conf
 sed -i "s/^user .*/user ${WEBUSER};/" /etc/nginx/nginx.conf
 sed -i "s/CACHE_MEM_SIZE/${CACHE_MEM_SIZE}/"  /etc/nginx/conf.d/20_proxy_cache_path.conf
 sed -i "s/CACHE_DISK_SIZE/${CACHE_DISK_SIZE}/" /etc/nginx/conf.d/20_proxy_cache_path.conf
 sed -i "s/CACHE_MAX_AGE/${CACHE_MAX_AGE}/"    /etc/nginx/sites-available/generic.conf.d/root/20_cache.conf
-sed -i "s/slice 1m;/slice ${CACHE_SLICE_SIZE:-1m};/" /etc/nginx/sites-available/generic.conf.d/root/20_cache.conf
+sed -i "s/slice 1m;/slice ${CACHE_SLICE_SIZE};/" /etc/nginx/sites-available/generic.conf.d/root/20_cache.conf
 sed -i "s/UPSTREAM_DNS/${UPSTREAM_DNS}/"    /etc/nginx/sites-available/generic.conf.d/10_generic.conf

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,40 +1,9 @@
 #!/bin/bash
-which goss
 
-if [ $? -ne 0 ]; then
-	echo "Please install goss from https://goss.rocks/install"
-	echo "For a quick auto install run the following"
-	echo "curl -fsSL https://goss.rocks/install | sh"
-	exit $?
+if [[ "$@" == *" -- "* ]]; then
+	SD_LOGLEVEL="-e SUPERVISORD_LOGLEVEL=INFO"
+else
+	SD_LOGLEVEL="-- -e SUPERVISORD_LOGLEVEL=INFO"
 fi
 
-docker build --tag lancachenet/generic:goss-test .
-case $1 in
-  circleci)
-    shift;
-    mkdir -p ./reports/goss
-	if [[ "$1" == "keepimage" ]]; then
-		KEEPIMAGE=true
-		shift
-	fi
-    export GOSS_OPTS="$GOSS_OPTS --format junit"
-	dgoss run $@ lancachenet/generic:goss-test > reports/goss/report.xml
-	#store result for exit code
-	RESULT=$?
-	#delete the junk that goss currently outputs :(
-    sed -i '0,/^</d' reports/goss/report.xml
-	#remove invalid system-err outputs from junit output so circleci can read it
-	sed -i '/<system-err>.*<\/system-err>/d' reports/goss/report.xml
-    ;;
-  *)
-	if [[ "$1" == "keepimage" ]]; then
-		KEEPIMAGE=true
-		shift
-	fi
-	dgoss run $@ lancachenet/generic:goss-test
-	RESULT=$?
-    ;;
-esac
-[[ "$KEEPIMAGE" == "true" ]] || docker rmi lancachenet/generic:goss-test
-
-exit $RESULT
+curl -fsSL https://raw.githubusercontent.com/lancachenet/test-suite/master/dgoss-tests.sh | bash -s -- --imagename="lancachenet/generic:goss-test" $@ $SD_LOGLEVEL


### PR DESCRIPTION
Added env variable CACHE_SLICE_SIZE (default 1m) to allow tuning

This can cause cache invalidation so we have also added some sanity checks to stop people accidentally changing their config. These checks can be overriden at the users risk by creating /overriding the `/data/cache/CONFIGHASH` file with the new configuration