### PR TITLE
Add GWS Arenanet workaround for manifest caching.

### DIFF
--- a/overlay/etc/nginx/sites-available/generic.conf.d/20_arenanet_manifest.conf
+++ b/overlay/etc/nginx/sites-available/generic.conf.d/20_arenanet_manifest.conf
@@ -1,0 +1,4 @@
+  # Fix for GW2 manifest
+  location ^~ /latest64 {
+    proxy_pass http://$host;
+  }

--- a/overlay/etc/nginx/sites-available/generic.conf.d/20_arenanet_manifest.conf
+++ b/overlay/etc/nginx/sites-available/generic.conf.d/20_arenanet_manifest.conf
@@ -2,5 +2,5 @@
   location ^~ /latest64 {
 	proxy_cache_bypass 1;
 	proxy_no_cache 1;
-	proxy_pass http://$host$uri;
+	proxy_pass http://$host$request_uri;
   }

--- a/overlay/etc/nginx/sites-available/generic.conf.d/20_arenanet_manifest.conf
+++ b/overlay/etc/nginx/sites-available/generic.conf.d/20_arenanet_manifest.conf
@@ -1,4 +1,6 @@
   # Fix for GW2 manifest
   location ^~ /latest64 {
-    proxy_pass http://$host;
+	proxy_cache_bypass 1;
+	proxy_no_cache 1;
+	proxy_pass http://$host$uri;
   }


### PR DESCRIPTION
Create override for 'manifest' like behaviour on arenanet CDN.

When polling for updates, it checks the /latest64/ folder of the remote host.  When cached, no updates are ever seen.