### PR TITLE
exclude various certificate .cab files from caching. 

### DIFF
--- a/overlay/etc/nginx/sites-available/generic.conf.d/20_wsus_cabs.conf
+++ b/overlay/etc/nginx/sites-available/generic.conf.d/20_wsus_cabs.conf
@@ -1,0 +1,6 @@
+ # Fix for WSUS authroot cab files
+  location ~* (authrootstl.cab|pinrulesstl.cab|disallowedcertstl.cab)$ {
+	proxy_cache_bypass 1;
+	proxy_no_cache 1;
+	proxy_pass http://$host$request_uri;
+  }


### PR DESCRIPTION
These should always be proxied and never cached, as they are new trusted roots, expired and revoked certs etc.