### PR TITLE
Steam server status

### DIFF
--- a/overlay/etc/nginx/sites-available/generic.conf.d/20_steam_ss.conf
+++ b/overlay/etc/nginx/sites-available/generic.conf.d/20_steam_ss.conf
@@ -1,0 +1,6 @@
+  # Fix for STEAM CDN selection manifest
+  location = /server-status {
+	proxy_cache_bypass 1;
+	proxy_no_cache 1;
+	proxy_pass http://$host$request_uri;
+  }

--- a/overlay/etc/nginx/sites-available/generic.conf.d/20_wsus_cabs.conf
+++ b/overlay/etc/nginx/sites-available/generic.conf.d/20_wsus_cabs.conf
@@ -1,0 +1,6 @@
+ # Fix for WSUS authroot cab files
+  location ~* (authrootstl.cab|pinrulesstl.cab|disallowedcertstl.cab)$ {
+	proxy_cache_bypass 1;
+	proxy_no_cache 1;
+	proxy_pass http://$host$request_uri;
+  }


### PR DESCRIPTION
proxy /server-status instead of caching.  This allows better use of upstream CDN nodes.  Should fix #30 