### PR TITLE
prevent multiple requests while filling the cache

### DIFF
--- a/overlay/etc/nginx/sites-available/generic.conf.d/root/20_cache.conf
+++ b/overlay/etc/nginx/sites-available/generic.conf.d/root/20_cache.conf
@@ -11,6 +11,7 @@
     # getting the file multiple times.
     proxy_cache_lock on;
     proxy_cache_lock_timeout 1h;
+    proxy_cache_lock_age 1h;
 
     # Allow the use of state entries
     proxy_cache_use_stale error timeout invalid_header updating http_500 http_502 http_503 http_504;


### PR DESCRIPTION
while proxy_cache_lock_timeout is set to ensure the request is cached, there still can happen multiple requests to the origin server while the entry is being cached. This would result in reduced bandwidth for the proxy itself.

[0] https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_cache_lock_age