### PR TITLE
add separate proxy server

### DIFF
--- a/overlay/etc/nginx/sites-available/10_generic.conf
+++ b/overlay/etc/nginx/sites-available/10_generic.conf
@@ -8,3 +8,24 @@ server {
 
   include /etc/nginx/sites-available/generic.conf.d/*.conf;
 }
+
+server {
+  listen 3128 reuseport;
+
+  access_log /data/logs/access.log cachelog;
+  error_log /data/logs/error.log;
+
+  resolver UPSTREAM_DNS ipv6=off;
+
+  location / {
+    proxy_pass http://$host$request_uri;
+    proxy_intercept_errors on;
+    error_page 301 302 307 = @upstream_redirect;
+  }
+
+  location @upstream_redirect {
+    set $saved_upstream_location '$upstream_http_location';
+
+    proxy_pass $saved_upstream_location;
+  }
+}

--- a/overlay/etc/nginx/sites-available/generic.conf.d/root/90_upstream.conf
+++ b/overlay/etc/nginx/sites-available/generic.conf.d/root/90_upstream.conf
@@ -1,6 +1,6 @@
     # Upstream Configuration
     proxy_next_upstream error timeout http_404;
-    proxy_pass http://$host$request_uri;
+    proxy_pass http://127.0.0.1:3128$request_uri;
     proxy_redirect off;
     proxy_ignore_client_abort on;
 

--- a/overlay/hooks/entrypoint-pre.d/10_setup.sh
+++ b/overlay/hooks/entrypoint-pre.d/10_setup.sh
@@ -11,4 +11,5 @@ sed -i "s/CACHE_DISK_SIZE/${CACHE_DISK_SIZE}/" /etc/nginx/conf.d/20_proxy_cache_
 sed -i "s/CACHE_MAX_AGE/${CACHE_MAX_AGE}/"    /etc/nginx/sites-available/generic.conf.d/root/20_cache.conf
 sed -i "s/slice 1m;/slice ${CACHE_SLICE_SIZE};/" /etc/nginx/sites-available/generic.conf.d/root/20_cache.conf
 sed -i "s/UPSTREAM_DNS/${UPSTREAM_DNS}/"    /etc/nginx/sites-available/generic.conf.d/10_generic.conf
+sed -i "s/UPSTREAM_DNS/${UPSTREAM_DNS}/"    /etc/nginx/sites-available/10_generic.conf
 sed -i "s/UPSTREAM_DNS/${UPSTREAM_DNS}/"    /etc/nginx/stream-available/10_sni.conf


### PR DESCRIPTION
Usually 302 shouldn't be a problem. Clients would just hit the proxy with the new location from the 302. With slice and multiple cdn however an error can occure if some requests get a 200 and some a 302 as the slice won't be able to continue if it does not get the actual data.
Even though the psn part of the cache seems to be the only one affected it is a case that the proxy should handle as the error would not occore without the proxy.

Would love to get some reviews to improve the changes :)

One out of the many cdn providers sony is using does respond with 302 whereas all the others do give a 200.
```
# in order to find all the dns entries repeated lookups are required
nslookup gs2.ww.prod.dl.playstation.net

curl --head --header "Host: gs2.ww.prod.dl.playstation.net" http://sonycoment.vo.llnwd.net/gs2/ppkgo/prod/CUSA08670_00/45/f_f4ce2a687bbc6de7880fee4d2dab8805dfd0aed78f42ec32eb5b658f257ba17f/f/EP0006-CUSA08670_00-BATTLEFIELDV0000-A0138-V0100_0.pkg

curl --head --header "Host: gs2.ww.prod.dl.playstation.net" http://gs2.ww.prod.dl.playstation.net.c.footprint.net/gs2/ppkgo/prod/CUSA08670_00/45/f_f4ce2a687bbc6de7880fee4d2dab8805dfd0aed78f42ec32eb5b658f257ba17f/f/EP0006-CUSA08670_00-BATTLEFIELDV0000-A0138-V0100_0.pkg
```
fixes https://github.com/lancachenet/monolithic/issues/60